### PR TITLE
Memory leak when setting the default user agent

### DIFF
--- a/src/pycurl.c
+++ b/src/pycurl.c
@@ -786,8 +786,8 @@ util_curl_init(CurlObject *self)
     }
     strcpy(s, "PycURL/"); strcpy(s+7, LIBCURL_VERSION);
     res = curl_easy_setopt(self->handle, CURLOPT_USERAGENT, (char *) s);
+    free(s);
     if (res != CURLE_OK) {
-        free(s);
         return (-1);
     }
     return (0);


### PR DESCRIPTION
Hello,

This proposed change fixes a memory leak when setting the default PycURL user agent.

In libcurl's setstropt function (https://github.com/bagder/curl/blob/master/lib/url.c#L290), called by Curl_setopt, the s argument is copied by strdup. Since s is never freed, except on an error condition, it will be leaked.

Thank you.
