### PR TITLE
setup_hepers: Use only dynamic or static libcurl, but not both

### DIFF
--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -120,9 +120,10 @@ def make_posix_params(params):
     for option in ["--libs", "--static-libs"]:
         p = Popen("'%s' %s" % (curl_config, option), shell=True,
             stdout=PIPE)
-        (stdout, stderr) = p.communicate()
+        (optbuf, stderr) = p.communicate()
         if p.wait() == 0:
-            optbuf += stdout
+            break
+
     if not optbuf:
         write_and_exit(['Neither of curl-config --libs or --static-libs produced output'])
 


### PR DESCRIPTION
Some platforms don't have static or some don't have dynamic libcurl, so i think it's better to build dynamicly if dynamic libs are avalible and staticly if there are only static. It would be also nice to have an option to force build staticly. Still this is better behaviour than it was before, when curl-config returned parameters no matter if there were libs avalible or not.
