### PR TITLE
Fixed issue parsing custom options

### DIFF
--- a/setup_helpers.py
+++ b/setup_helpers.py
@@ -39,6 +39,7 @@ def parse_args():
             if arg.startswith('--%s' % option.replace("_", "-")):
                 try:
                     options[option] = arg.split("=")[1]
+                    sys.argv.remove(arg)
                 except IndexError:
                     continue
 


### PR DESCRIPTION
Setuptools fails on unrecognized options (ex. --curl-config=...)
this patch removes custom options from sys.argv when they are parsed.

Problem presents on setuptools 1.0

Ex.

% python2.7 setup.py build --curl-config=/usr/bin/curl-config
Using /usr/bin/curl-config (libcurl 7.32.0)

Using curl directory: None
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --curl-config not recognized
